### PR TITLE
UI: Add missing "#include <QPainterPath>"

### DIFF
--- a/UI/WaveFormChunk.cpp
+++ b/UI/WaveFormChunk.cpp
@@ -20,6 +20,7 @@
 
 #include "WaveFormChunk.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QtMath>
 #include <QtCore>
 #include "Signal.h"


### PR DESCRIPTION
Error was:
> ```
> g++ -c -pipe -O2 -std=gnu++11 -Wall -Wextra -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -IUI -I/usr/include/qt5 -I/usr/include/qt5/QtMultimedia -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtCore -I. -I. -I/usr/lib64/qt5/mkspecs/linux-g++ -o WaveFormChunk.o UI/WaveFormChunk.cpp
> UI/WaveFormChunk.cpp: In member function ‘void WaveFormChunk::updateWave(Signal*)’:
> UI/WaveFormChunk.cpp:61:26: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
>    61 |             QPainterPath path;
>       |                          ^~~~
> ```