### PR TITLE
Exceptions.h: Add missing "noexcept"

### DIFF
--- a/Exceptions.h
+++ b/Exceptions.h
@@ -29,7 +29,7 @@ class NotImplementedException : public QException
 public:
     virtual void raise() const override { throw *this; }
     virtual NotImplementedException* clone() const override { return new NotImplementedException(*this); }
-    virtual const char* what() const override { return "Function is not implemented"; }
+    virtual const char* what() const noexcept override { return "Function is not implemented"; }
 };
 
 // Used to announce an error in one of the arguments passed to a function
@@ -41,7 +41,7 @@ public:
 
     virtual void raise() const override { throw *this; }
     virtual ArgumentException* clone() const override { return new ArgumentException(*this); }
-    virtual const char* what() const override { return m_message.c_str(); }
+    virtual const char* what() const noexcept override { return m_message.c_str(); }
 private:
     std::string m_message;
 };


### PR DESCRIPTION
Error was:
> ```
> g++ -c -pipe -O2 -std=gnu++11 -Wall -Wextra -D_REENTRANT -fPIC -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_MULTIMEDIA_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -IUI -I/usr/include/qt5 -I/usr/include/qt5/QtMultimedia -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtCore -I. -I. -I/usr/lib64/qt5/mkspecs/linux-g++ -o SampleConverter.o SampleConverter.cpp
> In file included from SampleConverter.cpp:22:
> Exceptions.h:32:25: error: looser exception specification on overriding virtual function ‘virtual const char* NotImplementedException::what() const’
>    32 |     virtual const char* what() const override { return "Function is not implemented"; }
>       |                         ^~~~
> In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/new:41,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/stl_construct.h:59,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/stl_tempbuf.h:60,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/stl_algo.h:62,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/algorithm:62,
>                  from /usr/include/qt5/QtCore/qglobal.h:142,
>                  from /usr/include/qt5/QtCore/QtCore:4,
>                  from SampleConverter.h:24,
>                  from SampleConverter.cpp:21:
> /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/exception.h:76:5: note: overridden function is ‘virtual const char* std::exception::what() const noexcept’
>    76 |     what() const _GLIBCXX_TXN_SAFE_DYN _GLIBCXX_NOTHROW;
>       |     ^~~~
> In file included from SampleConverter.cpp:22:
> Exceptions.h:44:25: error: looser exception specification on overriding virtual function ‘virtual const char* ArgumentException::what() const’
>    44 |     virtual const char* what() const override { return m_message.c_str(); }
>       |                         ^~~~
> In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/new:41,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/stl_construct.h:59,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/stl_tempbuf.h:60,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/stl_algo.h:62,
>                  from /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/algorithm:62,
>                  from /usr/include/qt5/QtCore/qglobal.h:142,
>                  from /usr/include/qt5/QtCore/QtCore:4,
>                  from SampleConverter.h:24,
>                  from SampleConverter.cpp:21:
> /usr/lib/gcc/x86_64-pc-linux-gnu/11/include/g++-v11/bits/exception.h:76:5: note: overridden function is ‘virtual const char* std::exception::what() const noexcept’
>    76 |     what() const _GLIBCXX_TXN_SAFE_DYN _GLIBCXX_NOTHROW;
>       |     ^~~~
> ```